### PR TITLE
Sync the Konflux Dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -10,9 +10,11 @@ COPY ${SOURCE_CODE} .
 USER root
 
 RUN echo "Installing Runtime Dependencies" && \
+    dnf install -y skopeo && dnf clean all && \
     pip install --no-cache-dir -r requirements.txt && \
     chgrp -R 0 . && \
-    chmod -R g=u .
+    chmod -R g=u . && \
+    mv mixtral-tokenizer /models
 
 USER default
 


### PR DESCRIPTION
This sync to the Konflux Dockerfile was missed as part of the work for: https://issues.redhat.com/browse/RHOAIENG-21302.