### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-ml-pipelines-runtime-generic-v2-23

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -21,7 +21,8 @@ USER default
 # Default for ubi8/python
 WORKDIR /opt/app-root/src
 
-LABEL name="odh-ml-pipelines-runtime-generic" \
+LABEL name="rhoai/odh-ml-pipelines-runtime-generic-rhel9" \
+    cpe="cpe:/a:redhat:openshift_ai:2.23::el9" \
     com.redhat.component="odh-ml-pipelines-runtime-generic-container" \
     summary="Generic runtime image for pipeline tasks with embedded managed pipelines." \
     description="Generic runtime image for pipeline tasks with embedded managed pipelines." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
